### PR TITLE
Homework 3 (in-memory cache)

### DIFF
--- a/05_concurrency/homework/afterfunc/afterfunc.go
+++ b/05_concurrency/homework/afterfunc/afterfunc.go
@@ -1,0 +1,70 @@
+package afterfunc
+
+import (
+	"memcache/interfaces"
+	"sync"
+	"time"
+)
+
+type cache struct {
+	mu      sync.Mutex
+	records map[interfaces.Key]*record
+}
+
+type record struct {
+	value       interface{}
+	ttl         time.Duration
+	deleteTimer *time.Timer
+}
+
+func New() interfaces.Cache {
+	return &cache{
+		records: make(map[interfaces.Key]*record),
+	}
+}
+
+func (c *cache) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, record := range c.records {
+		record.deleteTimer.Stop()
+	}
+}
+
+func (c *cache) Set(key interfaces.Key, value interface{}, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.records[key]
+	if !ok {
+		r = &record{}
+		c.records[key] = r
+		r.deleteTimer = time.AfterFunc(ttl, func() {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			delete(c.records, key)
+		})
+	} else {
+		r.deleteTimer.Reset(ttl)
+	}
+	r.value, r.ttl = value, ttl
+}
+
+func (c *cache) Get(key interfaces.Key) (value interface{}, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	record, ok := c.records[key]
+	if ok {
+		record.deleteTimer.Reset(record.ttl)
+		value = record.value
+	}
+	return
+}
+
+func (c *cache) Delete(key interfaces.Key) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if record, ok := c.records[key]; ok {
+		record.deleteTimer.Stop()
+		delete(c.records, key)
+	}
+}

--- a/05_concurrency/homework/checkall/checkall.go
+++ b/05_concurrency/homework/checkall/checkall.go
@@ -1,0 +1,73 @@
+package checkall
+
+import (
+	"memcache/interfaces"
+	"sync"
+	"time"
+)
+
+type cache struct {
+	mu      sync.Mutex
+	records map[interfaces.Key]*record
+	stop    chan struct{}
+}
+
+type record struct {
+	value interface{}
+	ttl   time.Duration
+	birth time.Time
+}
+
+func New(sweepInterval time.Duration) interfaces.Cache {
+	c := &cache{
+		records: make(map[interfaces.Key]*record),
+		stop:    make(chan struct{}),
+	}
+	go func() {
+		ticker := time.NewTicker(sweepInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-c.stop:
+				return
+			case now := <-ticker.C:
+				c.mu.Lock()
+				for k, r := range c.records {
+					death := r.birth.Add(r.ttl)
+					if now.After(death) {
+						delete(c.records, k)
+					}
+				}
+				c.mu.Unlock()
+			}
+		}
+	}()
+	return c
+}
+
+func (c *cache) Stop() {
+	close(c.stop)
+}
+
+func (c *cache) Set(key interfaces.Key, value interface{}, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records[key] = &record{value, ttl, time.Now()}
+}
+
+func (c *cache) Get(key interfaces.Key) (value interface{}, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	record, ok := c.records[key]
+	if ok {
+		record.birth = time.Now()
+		value = record.value
+	}
+	return
+}
+
+func (c *cache) Delete(key interfaces.Key) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.records, key)
+}

--- a/05_concurrency/homework/go.mod
+++ b/05_concurrency/homework/go.mod
@@ -1,0 +1,1 @@
+module memcache

--- a/05_concurrency/homework/interfaces/interfaces.go
+++ b/05_concurrency/homework/interfaces/interfaces.go
@@ -1,0 +1,16 @@
+package interfaces
+
+import "time"
+
+type Key = string
+
+type Cache interface {
+	Set(key Key, value interface{}, ttl time.Duration)
+	Get(key Key) (interface{}, bool)
+	Delete(key Key)
+
+	// Cancels any scheduled sweeping.
+	// Some cache implementations may require to call Stop to avoid memory leaks.
+	// After calling Stop, further usage of the cache is invalid.
+	Stop()
+}

--- a/05_concurrency/homework/memcache_test.go
+++ b/05_concurrency/homework/memcache_test.go
@@ -1,0 +1,117 @@
+package memcache
+
+import (
+	"fmt"
+	"math/rand"
+	"memcache/afterfunc"
+	"memcache/checkall"
+	"memcache/interfaces"
+	"sync"
+	"testing"
+	"time"
+)
+
+func assertPresence(c interfaces.Cache, key interfaces.Key, value interface{}) {
+	if v, ok := c.Get(key); !ok || v != value {
+		panic(fmt.Sprint(v, ok))
+	}
+}
+func assertAbsence(c interfaces.Cache, key interfaces.Key) {
+	if _, ok := c.Get(key); ok {
+		panic("")
+	}
+}
+
+func cacheCreators(sweepInterval time.Duration) map[string]func() interfaces.Cache {
+	return map[string]func() interfaces.Cache{
+		"afterfunc": afterfunc.New,
+		"checkall":  func() interfaces.Cache { return checkall.New(sweepInterval) },
+	}
+}
+
+func TestBaseLogic(t *testing.T) {
+	long := time.Minute
+	for implName, newCache := range cacheCreators(100 * time.Millisecond) {
+		t.Run(implName, func(t *testing.T) {
+			c := newCache()
+			defer c.Stop()
+			c.Set("a", 9, long)
+			assertPresence(c, "a", 9)
+			c.Set("a", 3, long)
+			assertPresence(c, "a", 3)
+			c.Delete("a")
+			assertAbsence(c, "a")
+		})
+	}
+}
+
+func TestDeletingByTime(t *testing.T) {
+	for implName, newCache := range cacheCreators(10 * time.Millisecond) {
+		t.Run(implName, func(t *testing.T) {
+			c := newCache()
+			defer c.Stop()
+
+			c.Set("a", 1, 50*time.Millisecond)
+			c.Set("b", 2, 150*time.Millisecond)
+			assertPresence(c, "a", 1)
+			assertPresence(c, "b", 2)
+
+			time.Sleep(75 * time.Millisecond)
+			assertAbsence(c, "a")
+			assertPresence(c, "b", 2)
+
+			time.Sleep(140 * time.Millisecond)
+			assertPresence(c, "b", 2)
+			c.Set("b", 3, 50*time.Millisecond)
+			assertPresence(c, "b", 3)
+
+			time.Sleep(40 * time.Millisecond)
+			assertPresence(c, "b", 3)
+
+			time.Sleep(100 * time.Millisecond)
+			assertAbsence(c, "b")
+		})
+	}
+}
+
+// For `go test -race`
+func TestConcurrentUsage(t *testing.T) {
+	for implName, newCache := range cacheCreators(10 * time.Millisecond) {
+		t.Run(implName, func(t *testing.T) {
+			c := newCache()
+			defer c.Stop()
+			wg := sync.WaitGroup{}
+			goroutines := 1000
+			for i := 0; i < goroutines; i++ {
+				wg.Add(1)
+				i := i
+				go func() {
+					k := fmt.Sprint(i / (goroutines / 2)) // "0" or "1"
+					v, _ := c.Get(k)
+					if v == nil {
+						v = 0
+					}
+					c.Set(k, v.(int)+1, time.Minute)
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}
+
+func BenchmarkSet(b *testing.B) {
+	long := time.Hour
+	rand.Seed(time.Now().UnixNano())
+	for implName, newCache := range cacheCreators(long) {
+		b.Run(implName, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c := newCache()
+				defer c.Stop()
+				for j := 0; j < 10_000; j++ {
+					c.Set(fmt.Sprint(j), j, long+time.Duration(rand.Int31()))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
By Maxim Meshkov

Here are 2 implementations:
* `afterfunc`: uses `time.AfterFunc` for every cached value.
* `checkall`: uses `time.Ticker`, a separate goroutine periodically checks all values and deletes old ones from the cache (i.e. this goroutine _sweeps_).

Race detector results + benchmark results:
![image](https://user-images.githubusercontent.com/71576382/126083648-d89ba804-dcbe-4e75-9a67-fb13f3b3d782.png)

So `checkall` approach is 2 times faster and uses about 2 times less memory. But keep in mind that according to the benchmark conditions, no value invalidation and no sweeping happens during the benchmark.
